### PR TITLE
Add a Dockerfile

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,0 +1,8 @@
+# Using circle-build-health with Docker
+
+1. Run `$ docker build -t aptotude/circle-build-health:latest .`
+2. Run `$ docker run --rm -p 80:3000 -e "RAZZLE_USE_AUTH0=false" -e "RAZZLE_CIRCLE_CI_TOKEN=foobar" aptotude/circle-build-health:latest`. Replace the environment values with the configuration you need.
+
+## TODO:
+
+Create an auto-build on <https://hub.docker.com/> to build the Dockerfile and publish it to `aptotude/circle-build-health`. Then, step 1 can be removed above, and any end user can simply run the container with the run command above.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:8.12.0-alpine
+
+RUN apk add yarn
+
+COPY . /opt/circle-build-health
+WORKDIR /opt/circle-build-health
+RUN yarn install --production && \
+    yarn build
+
+
+EXPOSE 3000
+CMD yarn start:prod

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ yarn start:prod
 yarn start
 ```
 
+### Docker
+
+See <DOCKER.md>.
+
 ### Environment Variables
 
 This project uses [razzle](https://github.com/jaredpalmer/razzle), which means it uses its [awesome tooling around .env files](https://github.com/jaredpalmer/razzle#what-other-env-files-are-can-be-used). Here's [the latest documentation](https://github.com/jaredpalmer/razzle#environment-variables) on the environment variables supported via razzle.


### PR DESCRIPTION
This commit fixes #4. Adds a simple Dockerfile and adds instructions to
the README about how to use it. If we start publishing this Dockerfile
to Docker Hub, the README can be updated to only show the `docker run`
line.

Note, in my testing so far this is throwing errors about env vars that I haven't worked through yet. I _believe_ it will run with the environment variables configured correctly.