### PR TITLE
Improve the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,15 @@
 
 ### Production
 ```
-yarn start:prod
+$ yarn install --production
+$ yarn build
+$ yarn start:prod
 ```
 
 ### Development
 ```
-yarn start
+$ yarn install
+$ yarn start
 ```
 
 ### Environment Variables


### PR DESCRIPTION
The readme was missing some info about how to install dependencies and
build the project before running it. I added these to the "quick start"
instructions.